### PR TITLE
Support Windows based platforms in checkForHMMER

### DIFF
--- a/simplehmmer/simplehmmer.py
+++ b/simplehmmer/simplehmmer.py
@@ -166,7 +166,10 @@ def checkForHMMER():
     """
     # redirect stdout so we don't get mess!
     try:
-        exit_status = system('hmmsearch -h > /dev/null')
+        if sys.platform == "win32":
+            exit_status = system('hmmsearch -h > NUL')
+        else:
+            exit_status = system('hmmsearch -h > /dev/null')
     except:
       print "Unexpected error!", sys.exc_info()[0]
       raise

--- a/simplehmmer/simplehmmer.py
+++ b/simplehmmer/simplehmmer.py
@@ -171,7 +171,7 @@ def checkForHMMER():
         else:
             exit_status = system('hmmsearch -h > /dev/null')
     except:
-      print "Unexpected error!", sys.exc_info()[0]
+      print("Unexpected error!", sys.exc_info()[0])
       raise
 
     if exit_status != 0:


### PR DESCRIPTION
checkForHMMER has a bug, /dev/null (usually) doesn't exist on windows so checkForHMMER always fails, even if hmmsearch exists

To fix this, when sys.platform is win32, redirect to NUL instead of /dev/null

**This change has not been tested**